### PR TITLE
Add "fileName" to metadata of file nodes

### DIFF
--- a/shvspy/src/mainwindow.cpp
+++ b/shvspy/src/mainwindow.cpp
@@ -384,6 +384,15 @@ void MainWindow::editCponParameters(const QModelIndex &ix)
 	}
 }
 
+static QString content_type_to_files_filter(const std::string &content_type)
+{
+	static QMap<std::string, QString> files_filter_map = {
+		{ "application/gzip", "GZip compressed files (*.gz)" },
+	};
+
+	return files_filter_map.value(content_type);
+}
+
 void MainWindow::onAttributesTableContexMenu(const QPoint &point)
 {
 	QModelIndex index = ui->tblAttributes->indexAt(point);
@@ -426,8 +435,10 @@ void MainWindow::onAttributesTableContexMenu(const QPoint &point)
 		};
 		if (a == a_save_result_binary) {
 			QVariant v = index.data(AttributesModel::RpcValueRole);
-			const std::string &s = qvariant_cast<cp::RpcValue>(v).toString();
-			save_file(QString(), s);
+			const cp::RpcValue rpc_val = qvariant_cast<cp::RpcValue>(v);
+			const std::string &s = rpc_val.toString();
+			const std::string content_type = rpc_val.metaValue("contentType").toStdString();
+			save_file(content_type_to_files_filter(content_type), s);
 			return;
 		}
 		if (a == a_save_result_chainpack) {

--- a/shvspy/src/mainwindow.cpp
+++ b/shvspy/src/mainwindow.cpp
@@ -436,14 +436,18 @@ void MainWindow::onAttributesTableContexMenu(const QPoint &point)
 		}
 		if (a == a_save_result_chainpack) {
 			QVariant v = index.data(AttributesModel::RpcValueRole);
-			const std::string s = qvariant_cast<cp::RpcValue>(v).toChainPack();
-			save_file(tr("ChainPack files (*.chpk)"), s);
+			const cp::RpcValue rpc_val = qvariant_cast<cp::RpcValue>(v);
+			const std::string s = rpc_val.toChainPack();
+			const std::string file_name = rpc_val.metaValue("fileName").toStdString();
+			save_file(tr("ChainPack files (*.chpk)"), s, file_name + ".chpk");
 			return;
 		}
 		if (a == a_save_result_cpon) {
 			QVariant v = index.data(AttributesModel::RpcValueRole);
-			const std::string s = qvariant_cast<cp::RpcValue>(v).toCpon();
-			save_file(tr("Cpon files (*.cpon)"), s);
+			const cp::RpcValue rpc_val = qvariant_cast<cp::RpcValue>(v);
+			const std::string s = rpc_val.toCpon();
+			const std::string file_name = rpc_val.metaValue("fileName").toStdString();
+			save_file(tr("Cpon files (*.cpon)"), s, file_name + ".cpon");
 			return;
 		}
 	}


### PR DESCRIPTION
Metavalue "fileName" is used as a hint in the file save dialog.