### PR TITLE
shvspy: use QByteArray in QCryptographicHash::addData for QT prior to 6.3

### DIFF
--- a/shvspy/src/dlgaddedituser.cpp
+++ b/shvspy/src/dlgaddedituser.cpp
@@ -45,7 +45,11 @@ DlgAddEditUser::~DlgAddEditUser()
 static std::string sha1_hex(const std::string &s)
 {
 	QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 	hash.addData(QByteArrayView(s.data(), s.length()));
+#else
+	hash.addData(s.data(), s.length());
+#endif
 	return std::string(hash.result().toHex().constData());
 }
 


### PR DESCRIPTION

`QCryptographicHash::addData` uses `QByteArray `for versions prior to QT 6.3. Therefore `QByteArrayView` can be used only if conditions `QT_VERSION_MAJOR >= 6 `and `QT_VERSION_MINUR >= 3` are fulfilled.