### PR TITLE
flake.nix: use git submodules instead of flake input for libshv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0
       - name: Install Nix
-        uses: cachix/install-nix-action@v26
+        uses: cachix/install-nix-action@V28
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Build
-        run: nix --experimental-features 'nix-command flakes' build -L .
+        run: nix --experimental-features 'nix-command flakes' build -L "git+file://$(pwd)?submodules=1&rev=$(git rev-parse HEAD)"
       - name: Flake check
-        run: nix --experimental-features 'nix-command flakes' flake check .
+        run: nix --experimental-features 'nix-command flakes' flake check "git+file://$(pwd)?submodules=1&rev=$(git rev-parse HEAD)"
       - name: Format
         run: nix --experimental-features 'nix-command flakes' fmt && git diff --exit-code

--- a/flake.lock
+++ b/flake.lock
@@ -17,108 +17,7 @@
         "type": "indirect"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-utils",
-        "type": "indirect"
-      }
-    },
-    "libshv": {
-      "inputs": {
-        "flake-utils": "flake-utils_2",
-        "necrolog": "necrolog",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1724615472,
-        "narHash": "sha256-D68FssvzyHbFUSg/t025MugsiAS6Z1FdfzeL3wktCro=",
-        "owner": "silicon-heaven",
-        "repo": "libshv",
-        "rev": "db8a7ae30ee0e4870b51346cdf6d9583459fdc75",
-        "type": "github"
-      },
-      "original": {
-        "owner": "silicon-heaven",
-        "repo": "libshv",
-        "type": "github"
-      }
-    },
-    "necrolog": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1710239929,
-        "narHash": "sha256-Sy7absZtICGCYJkBV1/4wpI72743WgDHaMLJk7BhmLQ=",
-        "owner": "fvacek",
-        "repo": "necrolog",
-        "rev": "87ed76143e10a5d07d881795eac11a1429a09012",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fvacek",
-        "repo": "necrolog",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1709780214,
-        "narHash": "sha256-p4iDKdveHMhfGAlpxmkCtfQO3WRzmlD11aIcThwPqhk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f945939fd679284d736112d3d5410eb867f3b31c",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1710222005,
-        "narHash": "sha256-irXySffHz7b82dZIme6peyAu+8tTJr1zyxcfUPhqUrg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "9a9a7552431c4f1a3b2eee9398641babf7c30d0e",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1724395761,
         "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
@@ -135,41 +34,10 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "libshv": "libshv",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,10 @@
 {
   description = "Silicon Heaven Spy";
 
-  inputs.libshv.url = "github:silicon-heaven/libshv";
-
   outputs = {
     self,
     flake-utils,
     nixpkgs,
-    libshv,
   }: let
     inherit (flake-utils.lib) eachDefaultSystem;
     inherit (nixpkgs.lib) hasSuffix composeManyExtensions;
@@ -17,8 +14,6 @@
       stdenv,
       cmake,
       qt6,
-      libshvForClients,
-      necrolog,
       doctest,
       openldap,
       copyDesktopItems,
@@ -28,7 +23,7 @@
         name = "shvspy-${rev}";
         src = builtins.path {
           path = ./.;
-          filter = path: type: ! hasSuffix ".nix" path;
+          filter = path: _: ! hasSuffix ".nix" path;
         };
         buildInputs = [
           qt6.wrapQtAppsHook
@@ -37,8 +32,6 @@
           qt6.qtwebsockets
           qt6.qtsvg
           qt6.qtnetworkauth
-          necrolog
-          libshvForClients
           doctest
           openldap
         ];
@@ -56,8 +49,6 @@
           })
         ];
         cmakeFlags = [
-          "-DSHVSPY_USE_LOCAL_NECROLOG=ON"
-          "-DSHVSPY_USE_LOCAL_LIBSHV=ON"
           "-DUSE_QT6=ON"
         ];
         meta.mainProgram = "shvspy";
@@ -65,11 +56,10 @@
   in
     {
       overlays = {
-        pkgs = final: prev: {
+        pkgs = final: _: {
           shvspy = final.callPackage shvspy {};
         };
         default = composeManyExtensions [
-          libshv.overlays.default
           self.overlays.pkgs
         ];
       };


### PR DESCRIPTION
It is really easy to encounter broken state because nix's flake.lock is not updated by the upstream developers and thus we end up with broker build due to mismatching libshv and the shvspy code.

This pivots back to use submodules as upstream is using them to pin their dependencies.