### PR TITLE
Close server node after editing server settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,6 +170,7 @@ jobs:
             pkgconf
             static-compat-cmake
             static-compat-fontconfig
+            static-compat-openssl
             static-compat-pkgconf
             static-compat-qt6-base
             static-compat-qt6-networkauth
@@ -177,6 +178,7 @@ jobs:
             static-compat-qt6-svg
             static-compat-qt6-tools
             static-compat-qt6-websockets
+            static-compat-zstd
             upx
           )
           pacman -Syu --noconfirm "${PACKAGES[@]}"

--- a/shvspy/src/appversion.h
+++ b/shvspy/src/appversion.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define APP_VERSION "1.16.0"
+#define APP_VERSION "1.16.1"

--- a/shvspy/src/servertreemodel/shvbrokernodeitem.cpp
+++ b/shvspy/src/servertreemodel/shvbrokernodeitem.cpp
@@ -150,6 +150,8 @@ void ShvBrokerNodeItem::setBrokerProperties(const QVariantMap &props)
 	if(m_rpcConnection) {
 		delete m_rpcConnection;
 		m_rpcConnection = nullptr;
+		// Since we're closing the connection, we also need to close the server node.
+		close();
 	}
 	m_brokerPropeties = props;
 	setNodeId(m_brokerPropeties.value(brokerProperty::NAME).toString().toStdString());


### PR DESCRIPTION
Editting server settings always removes the server connection (becaue it needs to be reinitialized with the new settings). This leaves the tree in an invalid state, because an open server tree node assumes that the connection is open.